### PR TITLE
Step 5: Add arithmetic operation capabilities

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,5 +21,8 @@ assert 0 0
 assert 42 42
 assert 21 "5+20-4"
 assert 41 " 12 + 34 - 5 "
+assert 47 '5+6*7'
+assert 15 '5*(9-6)'
+assert 4 '(3+5)/2'
 
 echo OK


### PR DESCRIPTION
This patch introduces the initial recursive descent parser to parse the
sequence of tokens that include multiplication and division operations,
and parentheses. The operator precedences are defined by the production
rules, which are one-to-one mapped to parsing functions each other.

Signed-off-by: Taku Fukushima <f.tac.mac@gmail.com>