### PR TITLE
Step 6: Add unary operators

### DIFF
--- a/pcc.c
+++ b/pcc.c
@@ -229,10 +229,12 @@ Node *new_node_num(int val) {
 
 // Production rules:
 //   expr    = mul ("+" mul | "-" mul)*
-//   mul     = primary ("*" primary | "/" primary)*
+//   mul     = unary ("*" unary | "/" unary)*
+//   unary   = ("+"  | "-")? primary
 //   primary = num | "(" expr ")"
 Node *expr();
 Node *mul();
+Node *unary();
 Node *primary();
 
 /**
@@ -264,17 +266,36 @@ Node *expr() {
  * @return the constructed AST node
  */
 Node *mul() {
-  Node *node = primary();
+  Node *node = unary();
 
   for (;;) {
     if (consume('*')) {
-      node = new_node(ND_MUL, node, primary());
+      node = new_node(ND_MUL, node, unary());
     } else if (consume('/')) {
-      node = new_node(ND_DIV, node, primary());
+      node = new_node(ND_DIV, node, unary());
     } else {
       return node;
     }
   }
+}
+
+/**
+ * Parse tokes with the "unary" production rule
+ *
+ *   unary   = ("+"  | "-")? primary
+ *
+ * @return the constructed AST node
+ */
+Node *unary() {
+  if (consume('+')) {
+    return primary();
+  }
+
+  if (consume('-')) {
+    return new_node(ND_SUB, new_node_num(0), primary());
+  }
+
+  return primary();
 }
 
 /**

--- a/test.sh
+++ b/test.sh
@@ -24,5 +24,11 @@ assert 41 " 12 + 34 - 5 "
 assert 47 '5+6*7'
 assert 15 '5*(9-6)'
 assert 4 '(3+5)/2'
+assert 42 "+42"
+assert 42 "+2*+3*+7"
+assert 42 "-(-42)"
+assert 42 "-(-(-(-42))"
+assert 42 "-6*-7"
+assert 42 "-2 * +3 * -7"
 
 echo OK


### PR DESCRIPTION
This patch adds the support for unary operators, "+" and "-" precede the
integers, in the input, e.g., "-2*(-3)*7".

Signed-off-by: Taku Fukushima <f.tac.mac@gmail.com>