### PR TITLE
Step 9: Introduce local variables consist of a character

### DIFF
--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@ int main(int argc,  char **argv) {
   // Tokenize the argument.
   token = tokenize(argv[1]);
   // Parse the tokenized input.
-  Node *node = expr();
+  Node *node = program();
   // Generate the assembly code from the parsed AST.
   codegen(node);
 

--- a/pcc.h
+++ b/pcc.h
@@ -15,6 +15,7 @@
  */
 typedef enum {
   TK_RESERVED,  // Operator token
+  TK_IDENT,     // Identifier
   TK_NUM,       // Number token
   TK_EOF,       // End of file, which is the end of the input
 } TokenKind;
@@ -65,6 +66,16 @@ void error_at(char *loc, char *fmt, ...);
 bool consume(char *op);
 
 /**
+ * Consumes an identifier token.
+ *
+ * If the next token is an identifier, scan a token and return the node
+ * constructed for the identifier.
+ *
+ * @return the current identifier token
+ */
+Token *consume_ident();
+
+/**
  * Expects a valid token
  *
  * If the next token is the expected operator, scan a token. Otherwise report the
@@ -106,15 +117,17 @@ Token *tokenize(char *p);
  * The kind of abstract syntax tree (AST) nodes
  */
 typedef enum {
-  ND_ADD,   // +
-  ND_SUB,   // -
-  ND_MUL,   // *
-  ND_DIV,   // /
-  ND_NUM,   // Integer
-  ND_EQ,    // ==
-  ND_NE,    // !=
-  ND_LT,    // <
-  ND_LE,    // <=
+  ND_ADD,    // +
+  ND_SUB,    // -
+  ND_MUL,    // *
+  ND_DIV,    // /
+  ND_NUM,    // Integer
+  ND_EQ,     // ==
+  ND_NE,     // !=
+  ND_LT,     // <
+  ND_LE,     // <=
+  ND_ASSIGN, // Variable assignment
+  ND_LVAR,   // Local variable
 } NodeKind;
 
 typedef struct Node Node;
@@ -123,20 +136,26 @@ typedef struct Node Node;
  * The AST node type
  */
 struct Node {
-  NodeKind kind; // The kind of the node
-  const Node *lhs;     // Left hand side
-  const Node *rhs;     // Right hand side
-  int val;       // The value of the integer if the kind is ND_NUM
+  NodeKind kind;   // The kind of the node
+  const Node *lhs; // Left hand side
+  const Node *rhs; // Right hand side
+  int val;         // The value of the integer if the kind is ND_NUM
+  int offset;      // The offset for the variable only if the kind is ND_LVAR
 };
 
 /**
- * Parse tokens with the "expr" production rule
- *
- *   expr       = equality
- *
- * @return the constructed AST node
+ * The entire parsed code in AST.
  */
-Node *expr();
+extern Node *code[100];
+
+/**
+ * Parse tokens with the "program" production rule
+ *
+ *   stmt       = expr ";"
+ *
+ * The parsed result is store in the global variable "code".
+ */
+void *program();
 
 
 // Assembly code generator

--- a/test.sh
+++ b/test.sh
@@ -17,30 +17,38 @@ assert() {
   fi
 }
 
-assert 0 0
-assert 42 42
-assert 21 "5+20-4"
-assert 41 " 12 + 34 - 5 "
-assert 47 '5+6*7'
-assert 15 '5*(9-6)'
-assert 4 '(3+5)/2'
-assert 42 "+42"
-assert 42 "+2*+3*+7"
-assert 42 "-(-42)"
-assert 42 "-(-(-(-42))"
-assert 42 "-6*-7"
-assert 42 "-2 * +3 * -7"
-assert 1 "42==42"
-assert 0 "42!=42"
-assert 0 "42<42"
-assert 1 "42<=42"
-assert 0 "42>42"
-assert 1 "42<=42"
-assert 1 "1 * 2 * 3 * 7 == 42"
-assert 1 "6 * 7 == -7 * (-6)"
-assert 1 "1 * 2 * 3 * 7 == 42"
-assert 1 "(44 - 20 * 3 / 2) * 3 == 42"
-assert 1 "(42!=42)==0"
-assert 1 "42!=42==0"
+assert 0 "0;"
+assert 42 "42;"
+assert 21 "5+20-4;"
+assert 41 " 12 + 34 - 5 ;"
+assert 47 '5+6*7;'
+assert 15 '5*(9-6);'
+assert 4 '(3+5)/2;'
+assert 42 "+42;"
+assert 42 "+2*+3*+7;"
+assert 42 "-(-42);"
+assert 42 "-(-(-(-42));"
+assert 42 "-6*-7;"
+assert 42 "-2 * +3 * -7;"
+assert 1 "42==42;"
+assert 0 "42!=42;"
+assert 0 "42<42;"
+assert 1 "42<=42;"
+assert 0 "42>42;"
+assert 1 "42<=42;"
+assert 1 "1 * 2 * 3 * 7 == 42;"
+assert 1 "6 * 7 == -7 * (-6);"
+assert 1 "1 * 2 * 3 * 7 == 42;"
+assert 1 "(44 - 20 * 3 / 2) * 3 == 42;"
+assert 1 "(42!=42)==0;"
+assert 1 "42!=42==0;"
+assert 42 "a=42;"
+assert 42 "a=b=c=d=e=f=g=h=i=j=k=l=m=n=o=p=q=r=s=t=u=v=w=x=y=z=42;"
+assert 1 "a=0; b=1;"
+assert 25 "a=0;b=1;c=2;d=3;e=4;f=5;g=6;h=7;i=8;j=9;k=10;l=11;m=12;n=13;o=14;p=15;q=16;r=17;s=18;t=19;u=20;v=21;w=22;x=23;y=24;z=25;"
+assert 1 "a=0;a+1;"
+assert 25 "a=0;b=a+1;c=b+1;d=c+1;e=d+1;f=e+1;g=f+1;h=g+1;i=h+1;j=i+1;k=j+1;l=k+1;m=l+1;n=m+1;o=n+1;p=o+1;q=p+1;r=q+1;s=r+1;t=s+1;u=t+1;v=u+1;w=v+1;x=w+1;y=x+1;z=y+1;"
+assert 3 "a = 1; b = 2; c = a + b;"
+assert 42 "a=1; b=2; c=3; d=7; a*b*c*d;"
 
 echo OK

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -44,18 +44,39 @@ bool consume(char *op) {
 }
 
 /**
+ * Consumes an identifier token.
+ *
+ * If the next token is an identifier, scan a token and return the node
+ * constructed for the identifier.
+ *
+ * @return the current identifier token
+ */
+Token *consume_ident() {
+  if (token->kind != TK_IDENT ||
+      token->len != 1 ||
+      !('a' <= token->str[0] && token->str[0] <= 'z')) {
+    return NULL;
+  }
+
+  Token *cur = token;
+  token = token->next;
+
+  return cur;
+}
+
+/**
  * Expects a valid token
  *
- * If the next token is the expected operator, scan a token. Otherwise report the
+ * If the next token is the expected string, scan a token. Otherwise report the
  * error.
  *
- * @param op the pointer to the operator string
+ * @param op the pointer to the expected string
  */
 void expect(char *op) {
   if (token->kind != TK_RESERVED ||
       strlen(op) != token->len ||
       memcmp(token->str, op, token->len)) {
-    error_at(token->str, "expected \"%c\"", op);
+    error_at(token->str, "expected \"%s\"", op);
   }
   token = token->next;
 }
@@ -124,7 +145,12 @@ Token *tokenize(char *p) {
       continue;
     }
 
-    if (strchr("+-*/()<>=!", *p)) {
+    if ('a' <= *p && *p <= 'z') {
+      cur = new_token(TK_IDENT, cur, p++, 1);
+      continue;
+    }
+
+    if (strchr("+-*/()<>=!;", *p)) {
       if ((*p == '=' || *p == '!' || *p == '<' || *p == '>') && *(p+1) == '=') {
         cur = new_token(TK_RESERVED, cur, p, 2);
         p += 2;


### PR DESCRIPTION
This patch introduces the local variables consist of a character, i.e.,
a, b, c, ..., z, to which the numbers can be assigned. The assigned
variables can be used in the arithmetic operations.

To allow the variable assignments and their uses, the compiler is
modified to parse multiple statements that are comprised of the single
expressions ending with semicolons. Therefore the following inputs are
all valid.

- a=42;
- a=0; b+1;
- a = 1; b = 2; c = a + b
- a=1; b=2; c=3; d=7; a*b*c*d;

Signed-off-by: Taku Fukushima <f.tac.mac@gmail.com>