### PR TITLE
Step 10: Allow local variables to be multiple characters

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -10,7 +10,7 @@ static void gen_lval(const Node *node) {
   }
 
   printf("  mov rax, rbp\n");
-  printf("  sub rax, %d\n", node->offset);
+  printf("  sub rax, %d\n", node->lvar->offset);
   printf("  push rax\n");
 }
 
@@ -100,16 +100,16 @@ static void gen(const Node *node) {
 }
 
 /*
- * Generate prologue of the code and output it to stdout.
+ * Generate prologue of the function and output it to stdout.
  */
-static void gen_prologue() {
+static void gen_prologue(const Function *program) {
   printf("  push rbp\n");
   printf("  mov rbp, rsp\n");
-  printf("  sub rsp, 208\n");  // allocate 26 (chars) * 8 bytes for variables.
+  printf("  sub rsp, %d\n", program->stack_size);
 }
 
 /*
- * Generate epilogue of the code and output it to stdout.
+ * Generate epilogue of the function and output it to stdout.
  */
 static void gen_epilogue() {
   printf("  mov rsp, rbp\n");
@@ -121,21 +121,23 @@ static void gen_epilogue() {
  * Generate a complete assembly code that emulates stack machine from the AST
  * and output it to stdout.
  *
- * @param node the node from which the assembly code is generated
+ * @param program the function from which the assembly code is generated
  */
-void codegen(const Node *node) {
+void codegen(const Function *program) {
   printf(".intel_syntax noprefix\n");
   printf(".global main\n");
   printf("main:\n");
 
-  gen_prologue();
+  gen_prologue(program);
 
-  for (int i = 0; code[i]; i++) {
+  Node *cur = program->node;
+  while (cur) {
     // Generate a seris of assembly code descending the AST nodes.
-    gen(code[i]);
+    gen(cur);
 
     // Pop the top of the stack and load it to RAX.
     printf("  pop rax\n");
+    cur = cur->next;
   }
 
   gen_epilogue();

--- a/main.c
+++ b/main.c
@@ -17,9 +17,10 @@ int main(int argc,  char **argv) {
   // Tokenize the argument.
   token = tokenize(argv[1]);
   // Parse the tokenized input.
-  Node *node = program();
+  Function *prog = program();
+  LVar *lv = prog->locals;
   // Generate the assembly code from the parsed AST.
-  codegen(node);
+  codegen(prog);
 
   return 0;
 }

--- a/test.sh
+++ b/test.sh
@@ -50,5 +50,9 @@ assert 1 "a=0;a+1;"
 assert 25 "a=0;b=a+1;c=b+1;d=c+1;e=d+1;f=e+1;g=f+1;h=g+1;i=h+1;j=i+1;k=j+1;l=k+1;m=l+1;n=m+1;o=n+1;p=o+1;q=p+1;r=q+1;s=r+1;t=s+1;u=t+1;v=u+1;w=v+1;x=w+1;y=x+1;z=y+1;"
 assert 3 "a = 1; b = 2; c = a + b;"
 assert 42 "a=1; b=2; c=3; d=7; a*b*c*d;"
+assert 6 "foo = 1; bar = 2 + 3; foo + bar;"
+assert 0 "variablewithlongname = 1; anothervariablewithyetlongname = -1; variablewithlongname + anothervariablewithyetlongname;"
+assert 42 "a1ph4numname = 42; a1ph4numname;"
+assert 42 "foo_bar = 21; baz_ = 2; quxx = foo_bar * baz_;"
 
 echo OK

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -1,5 +1,19 @@
 #include "pcc.h"
 
+/*
+ * Examines if the character is an alphabet or '_'.
+ */
+static inline bool isalphau(char c) {
+  return isalpha(c) || c == '_';
+}
+
+/*
+ * Examines if the character is an alphabet, a number or '_'.
+ */
+static inline bool isalnumu(char c) {
+  return isalnum(c) || c == '_';
+}
+
 /**
  * Report an error.
  *
@@ -53,8 +67,7 @@ bool consume(char *op) {
  */
 Token *consume_ident() {
   if (token->kind != TK_IDENT ||
-      token->len != 1 ||
-      !('a' <= token->str[0] && token->str[0] <= 'z')) {
+      token->len < 1) {
     return NULL;
   }
 
@@ -145,8 +158,13 @@ Token *tokenize(char *p) {
       continue;
     }
 
-    if ('a' <= *p && *p <= 'z') {
-      cur = new_token(TK_IDENT, cur, p++, 1);
+    if (isalphau(*p)) {
+      int vlen = 1;
+      while (isalnumu(*(p+vlen))) {
+        vlen++;
+      }
+      cur = new_token(TK_IDENT, cur, p, vlen);
+      p += vlen;
       continue;
     }
 


### PR DESCRIPTION
Local characters are restricted to be comprised of the single characters
in the previous step. This patch modifies them to accept multiple
characters as their names.

This patch contains the refactoring of the way to hold the parsed AST
nodes as well . The input is considered a sequence of statements with
local variables, which is embraced by a function. In other words the
compiler parses the input as the single function and generates the
assembly code corresponds to the function as the content of the main
section.

Signed-off-by: Taku Fukushima <f.tac.mac@gmail.com>