### PR TITLE
Step 11: Add return statement

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -42,6 +42,13 @@ static void gen(const Node *node) {
       printf("  push rdi\n");
 
       return;
+    case ND_RETURN:
+      gen(node->lhs);
+      printf("  pop rax\n");
+      printf("  mov rsp, rbp\n");
+      printf("  pop rbp\n");
+      printf("  ret\n");
+      return;
   }
 
   gen(node->lhs);

--- a/parser.c
+++ b/parser.c
@@ -77,6 +77,7 @@ static Node *new_lvar_node(LVar *lvar) {
 // Production rules:
 //   program    = stmt*
 //   stmt       = expr ";"
+//              | "return" expr ";"
 //   expr       = assign
 //   assign     = equality ("=" assign)?
 //   equality   = relational ("==" relational | "!=" relational)*
@@ -123,11 +124,18 @@ Function *program() {
  * Parse tokens with the "stmt" production rule
  *
  *   stmt       = expr ";"
+ *              | "return" expr ";"
  *
  * @return the constructed AST node
  */
 static Node *stmt() {
-  Node *node = expr();
+  Node *node;
+
+  if (consume("return")) {
+    node = new_node(ND_RETURN, expr(), NULL);
+  } else {
+    node = expr();
+  }
   expect(";");
 
   return node;

--- a/pcc.h
+++ b/pcc.h
@@ -18,6 +18,7 @@ typedef enum {
   TK_RESERVED,  // Operator token
   TK_IDENT,     // Identifier
   TK_NUM,       // Number token
+  TK_RETURN,    // "return" token
   TK_EOF,       // End of file, which is the end of the input
 } TokenKind;
 
@@ -129,6 +130,7 @@ typedef enum {
   ND_LE,     // <=
   ND_ASSIGN, // Variable assignment
   ND_LVAR,   // Local variable
+  ND_RETURN, // Return statement
 } NodeKind;
 
 typedef struct LVar LVar;

--- a/test.sh
+++ b/test.sh
@@ -54,5 +54,8 @@ assert 6 "foo = 1; bar = 2 + 3; foo + bar;"
 assert 0 "variablewithlongname = 1; anothervariablewithyetlongname = -1; variablewithlongname + anothervariablewithyetlongname;"
 assert 42 "a1ph4numname = 42; a1ph4numname;"
 assert 42 "foo_bar = 21; baz_ = 2; quxx = foo_bar * baz_;"
+assert 0 "return 0;"
+assert 42 "return 42;"
+assert 3 "a = 1; b = 2; return a+b;"
 
 echo OK

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -47,7 +47,7 @@ void error_at(char *loc, char *fmt, ...) {
  * @return true if the next token is the expected operator, otherwise false
  */
 bool consume(char *op) {
-  if (token->kind != TK_RESERVED ||
+  if ((token->kind != TK_RESERVED && token->kind != TK_RETURN) ||
       strlen(op) != token->len ||
       memcmp(token->str, op, token->len)) {
     return false;
@@ -155,6 +155,12 @@ Token *tokenize(char *p) {
     // Skip the white spaces.
     if (isspace(*p)) {
       p++;
+      continue;
+    }
+
+    if (!strncmp(p, "return", 6) && !isalnumu(p[6])) {
+      cur = new_token(TK_RETURN, cur, p, 6);
+      p += 6;
       continue;
     }
 


### PR DESCRIPTION
This patch adds return statement that returns from the current function
setting RAX to the given value or the result of the given expression.
The stack pointer is made point to the base register and the popped
address previously pointed by the base register is loaded to base
register to restore the previous state before the function was called.

Signed-off-by: Taku Fukushima <f.tac.mac@gmail.com>