### PR TITLE
Step14: Add function calls

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -120,6 +120,19 @@ static void gen_block(const Node *node) {
 }
 
 /*
+ * Generates a series of assembly code for the function call.
+ */
+static void gen_funcall(const Node *node) {
+  if (node->kind != ND_FUNCALL) {
+    error_at(token->str, "Not a function call.");
+  }
+
+  printf("  call %s\n", node->name);
+  // Push the return value of the function on RAX.
+  printf("  push rax\n");
+}
+
+/*
  * Generate a series of assembly code that emulates stack machine from the AST
  *
  * @param node the node from which the assembly code is generated
@@ -158,6 +171,9 @@ static void gen(const Node *node) {
       return;
     case ND_BLOCK:
       gen_block(node);
+      return;
+    case ND_FUNCALL:
+      gen_funcall(node);
       return;
     case ND_RETURN:
       gen(node->lhs);

--- a/codegen.c
+++ b/codegen.c
@@ -2,6 +2,8 @@
 
 static int label_seq = 0;
 
+static const char* arg_regs[] = {"rdi", "rsi", "rdx", "rcx", "r8", "r9"};
+
 static void gen(const Node *node);
 
 /*
@@ -127,6 +129,22 @@ static void gen_funcall(const Node *node) {
     error_at(token->str, "Not a function call.");
   }
 
+  const Node *arg = node->lhs;
+  int argn = 0;
+  while (arg) {
+    if (argn > 5) {
+      fprintf(stderr, "More than six arguments are not supported yet.\n");
+      exit(-1);
+    }
+    // Generate the code for the argument.
+    gen(arg->lhs);
+    arg = arg->rhs;
+    argn++;
+  }
+
+  for (int i = 0; i < argn; i++) {
+    printf("  pop %s\n", arg_regs[i]);
+  }
   printf("  call %s\n", node->name);
   // Push the return value of the function on RAX.
   printf("  push rax\n");

--- a/pcc.h
+++ b/pcc.h
@@ -119,22 +119,23 @@ Token *tokenize(char *p);
  * The kind of abstract syntax tree (AST) nodes
  */
 typedef enum {
-  ND_ADD,    // +
-  ND_SUB,    // -
-  ND_MUL,    // *
-  ND_DIV,    // /
-  ND_NUM,    // Integer
-  ND_EQ,     // ==
-  ND_NE,     // !=
-  ND_LT,     // <
-  ND_LE,     // <=
-  ND_ASSIGN, // Variable assignment
-  ND_LVAR,   // Local variable
-  ND_IF,     // if statement
-  ND_WHILE,  // while statement
-  ND_FOR,    // for statement
-  ND_BLOCK,  // blocks
-  ND_RETURN, // Return statement
+  ND_ADD,      // +
+  ND_SUB,      // -
+  ND_MUL,      // *
+  ND_DIV,      // /
+  ND_NUM,      // Integer
+  ND_EQ,       // ==
+  ND_NE,       // !=
+  ND_LT,       // <
+  ND_LE,       // <=
+  ND_ASSIGN,   // Variable assignment
+  ND_LVAR,     // Local variable
+  ND_IF,       // if statement
+  ND_WHILE,    // while statement
+  ND_FOR,      // for statement
+  ND_BLOCK,    // blocks
+  ND_FUNCALL,  // function call
+  ND_RETURN,   // Return statement
 } NodeKind;
 
 typedef struct LVar LVar;
@@ -160,6 +161,7 @@ struct Node {
   const Node *rhs;   // Right hand side
   int val;           // The value of the integer if the kind is ND_NUM
   LVar *lvar;        // The local variable only if the kind is ND_LVAR
+  const char *name;  // The name of the funciton only if kind is ND_FUNCALL
 };
 
 /**

--- a/test.c
+++ b/test.c
@@ -1,0 +1,11 @@
+// Functions used in the tests. They should be compiled and linked to the
+// assembly code compiled by pcc with the existing compilers and linkders
+// sucn as gcc/clang and ld.
+
+int foo() {
+  return 42;
+}
+
+int bar(int a, int b) {
+  return a + b;
+}

--- a/test.sh
+++ b/test.sh
@@ -92,5 +92,8 @@ assert 89 "a = 0; b = 1; for (i = 0; i < 10; i = i + 1) { tmp = b; b = a + b; a 
 assert 42 "{{{{{ return 42; }}}}}"
 
 assert_funcall 42 "foo();"
+assert_funcall 1 "bar(0, 1);"
+assert_funcall 14 "bar(1*2, 3*4);"
+assert_funcall 42 "bar(3*7, -3*(-7));"
 
 echo OK

--- a/test.sh
+++ b/test.sh
@@ -17,6 +17,24 @@ assert() {
   fi
 }
 
+assert_funcall() {
+  expected="$1"
+  input="$2"
+
+  cc -c test.c
+  ./pcc "$input" > tmp.s
+  cc -o tmp tmp.s test.o
+  ./tmp
+  actual="$?"
+
+  if [[ "$actual" = "$expected" ]]; then
+    echo "$input => $actual"
+  else
+    echo "$input => $expected expected, but got $actual"
+    exit 1
+  fi
+}
+
 assert 0 "0;"
 assert 42 "42;"
 assert 21 "5+20-4;"
@@ -72,5 +90,7 @@ assert 1 "{ a = 0; b = 1; return (a + b); }"
 assert 42 "if (0 < 1) { a = 42; return a; } else { return 1; }"
 assert 89 "a = 0; b = 1; for (i = 0; i < 10; i = i + 1) { tmp = b; b = a + b; a = tmp; } b;"
 assert 42 "{{{{{ return 42; }}}}}"
+
+assert_funcall 42 "foo();"
 
 echo OK

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -198,7 +198,7 @@ Token *tokenize(char *p) {
       continue;
     }
 
-    if (strchr("+-*/()<>{}=!;", *p)) {
+    if (strchr("+-*/()<>{}=!;,", *p)) {
       if ((*p == '=' || *p == '!' || *p == '<' || *p == '>') && *(p+1) == '=') {
         cur = new_token(TK_RESERVED, cur, p, 2);
         p += 2;


### PR DESCRIPTION
This PR adds the support for function calls. The function call support comes as the following two commits:

- No argument function call support
    - This supports the function call like `foo();`
- Function calls with arguments support
    - This supports the complete function calls with up to six arguments like `foo(1, ,2 3);`

Currently the number of the arguments is constrained to up to six and variable arguments and more than six arguments are not supported.

The tests where the compiled assembly code is linked with a regular object file compiled from a C code,`test.c`, by the existing compiler, i.e., GCC or Clang, are added as well.